### PR TITLE
call login() instead of returning null

### DIFF
--- a/CourseManagementSystem/src/coursemanagementsystem/UserInputManager.java
+++ b/CourseManagementSystem/src/coursemanagementsystem/UserInputManager.java
@@ -72,7 +72,8 @@ public class UserInputManager {
                 break;
         }
         System.out.println("Wrong id or password. Please try again.");
-        return null;
+        // call login() again if user enters wrong combination
+        return login();
     }
 
     public static void displayActions(Object accountType) {


### PR DESCRIPTION
We should call login() method again if the user enters wrong username password combination instead of returning null